### PR TITLE
add ability for random seed to be fixed per clevrgridenv instance

### DIFF
--- a/env.py
+++ b/env.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 
 import json
 import os
-import random
 import re
 import itertools
 

--- a/env.py
+++ b/env.py
@@ -36,6 +36,7 @@ import third_party.clevr_robot_env_utils.question_engine as qeng
 
 from utils import load_utils
 from utils.xml_utils import convert_scene_to_xml
+from utils import seeding_utils
 
 import cv2
 import mujoco_env as mujoco_env  # custom mujoco_env
@@ -86,9 +87,11 @@ four_cardinal_vectors_names = ['front', 'behind', 'left', 'right']
 
 class ClevrGridEnv(mujoco_env.MujocoEnv, utils.EzPickle):
   
-  def __init__(self, num_object=5, description_template_path=None, question_template_path=None, collision=False, top_down_view=False):
+  def __init__(self, num_object=5, description_template_path=None, question_template_path=None, collision=False, top_down_view=False, clevr_seed=0, mujoco_seed=1):
 
     utils.EzPickle.__init__(self)
+    self.rng = seeding_utils.create_rng(clevr_seed)
+    self.mujoco_seed = mujoco_seed
     self.min_dist = -0.5
     self.max_dist = 0.5
     self.curr_step = 0
@@ -187,6 +190,7 @@ class ClevrGridEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         self,
         self.initial_xml_path,
         self.frame_skip,
+        self.mujoco_seed,
         max_episode_steps=self.maximum_episode_steps,
         reward_threshold=self.reward_threshold,
         object_positions=None
@@ -239,7 +243,7 @@ class ClevrGridEnv(mujoco_env.MujocoEnv, utils.EzPickle):
       new_coords = [init + disp for init, disp in zip(init_coords, displacement)]
       new_coords_list.append(new_coords)
             
-    self.scene_graph, self.scene_struct = gs.generate_scene_struct(self.c2w, self.min_dist, self.max_dist, self.num_object, new_coords_list)
+    self.scene_graph, self.scene_struct = gs.generate_scene_struct(self.c2w, self.min_dist, self.max_dist, self.rng, self.num_object, new_coords_list)
     self.scene_struct['relationships'] = gs.compute_relationship(self.scene_struct, use_polar=self.use_polar)
     self._update_description()
     self.curr_step += 1
@@ -248,6 +252,7 @@ class ClevrGridEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         self,
         DEFAULT_XML_PATH,
         20,
+        self.mujoco_seed,
         max_episode_steps=100,
         reward_threshold=0.,
         object_positions=obj_pos
@@ -289,6 +294,7 @@ class ClevrGridEnv(mujoco_env.MujocoEnv, utils.EzPickle):
           self,
           self.initial_xml_path,
           self.frame_skip,
+          self.mujoco_seed,
           max_episode_steps=self.max_episode_steps,
           reward_threshold=self.reward_threshold,
           object_positions=positions
@@ -318,7 +324,7 @@ class ClevrGridEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         candidates = self.all_questions
       else:
         candidates = self.valid_questions
-      random.shuffle(candidates)
+      self.rng.shuffle(candidates)
       false_question_count = 0
 
       for q, p in candidates:
@@ -330,7 +336,7 @@ class ClevrGridEnv(mujoco_env.MujocoEnv, utils.EzPickle):
           currently_false.append((q, p, fixed_object_idx, fixed_object_loc))
           false_question_count += 1
 
-      random.shuffle(currently_false)
+      self.rng.shuffle(currently_false)
     
     self.step_discrete(a)
 
@@ -401,10 +407,10 @@ class ClevrGridEnv(mujoco_env.MujocoEnv, utils.EzPickle):
       return gs.generate_fixed_scene_struct(self.c2w, self.num_object,
                                       obj_pos=[[0, 0, 0.1], [0.2, 0.1, 0.1]])
     if self.variable_scene_content:
-      return gs.generate_scene_struct(self.c2w, self.min_dist, self.max_dist, self.num_object,
+      return gs.generate_scene_struct(self.c2w, self.min_dist, self.max_dist, self.rng, self.num_object,
                                       self.clevr_metadata)
     else:
-      return gs.generate_scene_struct(self.c2w, self.min_dist, self.max_dist, self.num_object)
+      return gs.generate_scene_struct(self.c2w, self.min_dist, self.max_dist, self.rng, self.num_object)
     
   def get_description(self):
     """Update and return the current scene description."""
@@ -582,6 +588,7 @@ class ClevrGridEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         self.clevr_metadata,
         self.desc_templates,
         self.ques_templates,
+        self.rng,
         description=True,
         templates_per_image=tn,
         instances_per_template=dn,

--- a/example.py
+++ b/example.py
@@ -28,7 +28,7 @@ from env import ClevrGridEnv
 FLAGS = flags.FLAGS
 
 def main(_):
-  env = ClevrGridEnv()
+  env = ClevrGridEnv(clevr_seed=0, mujoco_seed=0)
   
   rgb = env.render(mode='rgb_array')
   PLT.imshow(rgb)

--- a/example_collisions.py
+++ b/example_collisions.py
@@ -38,7 +38,7 @@ DIRECTIONS = ['left', 'right', 'front', 'behind']
 
 def main(_):
   file_dir = os.path.abspath(os.path.dirname(__file__))
-  env = ClevrGridEnv(num_object=2, description_template_path=os.path.join(
+  env = ClevrGridEnv(clevr_seed=0, mujoco_seed=0, num_object=2, description_template_path=os.path.join(
     file_dir, 'templates/description_distribution_collision.json'), question_template_path=os.path.join(
     file_dir, 'templates/question_distribution_collision.json'), collision=True)
   
@@ -51,7 +51,7 @@ def main(_):
   
   print('Initial coordinates:\n', 'Red sphere:', env.scene_struct['objects'][0]['3d_coords'], '\n', 'Blue sphere:', env.scene_struct['objects'][1]['3d_coords'])
   
-  dir_idx = np.random.randint(low=0, high=len(DIRECTION_COORDS))
+  # dir_idx = np.random.randint(low=0, high=len(DIRECTION_COORDS))
   # object = np.random.randint(low=0, high=env.num_object)
   object = 0
   force = np.zeros(env.num_object * 2)

--- a/example_llm_action_samples.py
+++ b/example_llm_action_samples.py
@@ -26,7 +26,7 @@ DIRECTIONS = ['left', 'right', 'front', 'behind']
 DIRECT_COMB = [('left', 'front'), ('left', 'behind'), ('right', 'front'), ('right', 'behind')]
 
 def main(_):
-  env = ClevrGridEnv()
+  env = ClevrGridEnv(clevr_seed=0, mujoco_seed=0)
   
   rgb = env.render(mode='rgb_array')
   PLT.imshow(rgb)

--- a/example_llm_samples.py
+++ b/example_llm_samples.py
@@ -26,7 +26,7 @@ DIRECTIONS = ['left', 'right', 'front', 'behind']
 DIRECT_COMB = [('left', 'front'), ('left', 'behind'), ('right', 'front'), ('right', 'behind')]
 
 def main(_):
-  env = ClevrGridEnv()
+  env = ClevrGridEnv(clevr_seed=0, mujoco_seed=0)
   
   description, colors_leftout = env.get_formatted_description()
   print('Descriptions: ', description)

--- a/mujoco_env.py
+++ b/mujoco_env.py
@@ -31,7 +31,7 @@ import numpy as np
 class MujocoEnv(gym.Env):
   """Custom Mujoco environment that uses dm control's wrapper."""
 
-  def __init__(self, model_path, frame_skip, max_episode_steps=None,
+  def __init__(self, model_path, frame_skip, seed, max_episode_steps=None,
                reward_threshold=None, object_positions=None):
 
     if model_path.startswith('/'):
@@ -78,7 +78,7 @@ class MujocoEnv(gym.Env):
     self.max_episode_steps = max_episode_steps
     self.reward_threshold = reward_threshold
 
-    self.seed()
+    self.seed(seed)
     self.camera_setup()
 
   def seed(self, seed=None):

--- a/third_party/clevr_robot_env_utils/generate_question.py
+++ b/third_party/clevr_robot_env_utils/generate_question.py
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 import json
 import os
-# import random
 import re
 import time
 

--- a/third_party/clevr_robot_env_utils/generate_question.py
+++ b/third_party/clevr_robot_env_utils/generate_question.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 
 import json
 import os
-import random
+# import random
 import re
 import time
 
@@ -40,6 +40,7 @@ def generate_question_from_scene_struct(scene_struct,
                                         metadata,
                                         desc_templates,
                                         ques_templates,
+                                        rng,
                                         description=True,
                                         instances_per_template=20,
                                         templates_per_image=3,
@@ -64,6 +65,7 @@ def generate_question_from_scene_struct(scene_struct,
         template,
         metadata,
         synonyms,
+        rng,
         verbose=False,
         use_synonyms=use_synonyms)
     for t, q, a in zip(ts, qs, ans):
@@ -87,7 +89,7 @@ def generate_question_from_scene_struct(scene_struct,
 def instantiate_templates_dfs(scene_struct,
                               template,
                               metadata,
-                              synonyms,
+                              synonyms, rng,
                               verbose=False,
                               use_synonyms=True):
   param_name_to_type = {p['name']: p['type'] for p in template['params']}
@@ -325,6 +327,7 @@ def instantiate_templates_dfs(scene_struct,
             answer,
             scene_struct,
             metadata,
+            rng,
             unique=unique,
             include_zero=include_zero)
       else:
@@ -347,10 +350,10 @@ def instantiate_templates_dfs(scene_struct,
             # For filter_count add nulls equal to the number of singletons
             num_to_add = sum(
                 1 for k, v in filter_options.items() if len(v) == 1)
-          add_empty_filter_options(filter_options, metadata, num_to_add)
+          add_empty_filter_options(filter_options, metadata, num_to_add, rng)
 
       filter_option_keys = list(filter_options.keys())
-      random.shuffle(filter_option_keys)
+      rng.shuffle(filter_option_keys)
       for k in filter_option_keys:
         new_nodes = []
         cur_next_vals = {k: v for k, v in state['vals'].items()}
@@ -423,7 +426,7 @@ def instantiate_templates_dfs(scene_struct,
       param_name = next_node['side_inputs'][0]
       param_type = param_name_to_type[param_name]
       param_vals = metadata['types'][param_type][:]
-      random.shuffle(param_vals)
+      rng.shuffle(param_vals)
       for val in param_vals:
         input_map = {k: v for k, v in state['input_map'].items()}
         input_map[state['next_template_node']] = len(state['nodes'])
@@ -461,13 +464,13 @@ def instantiate_templates_dfs(scene_struct,
   for state in final_states:
     structured_questions.append(state['nodes'])
     answers.append(state['answer'])
-    text = random.choice(template['text'])
+    text = rng.choice(template['text'])
     for name, val in state['vals'].items():
       if val in synonyms and use_synonyms:
-        val = random.choice(synonyms[val])
+        val = rng.choice(synonyms[val])
       text = text.replace(name, val)
       text = ' '.join(text.split())
-    text = replace_optionals(text)
+    text = replace_optionals(text, rng)
     text = ' '.join(text.split())
     text = other_heuristic(text, state['vals'])
     text_questions.append(text)
@@ -476,7 +479,7 @@ def instantiate_templates_dfs(scene_struct,
 
 
 # =============================================================================
-def replace_optionals(s):
+def replace_optionals(s, rng):
   """
   Each substring of s that is surrounded in square brackets is treated as
   optional and is removed with probability 0.5. For example the string
@@ -500,7 +503,7 @@ def replace_optionals(s):
       break
     i0 = match.start()
     i1 = match.end()
-    if random.random() > 0.5:
+    if rng.random() > 0.5:
       s = s[:i0] + match.groups()[0] + s[i1:]
     else:
       s = s[:i0] + s[i1:]
@@ -558,7 +561,7 @@ def find_filter_options(object_idxs, scene_struct, metadata):
   return attribute_map
 
 
-def add_empty_filter_options(attribute_map, metadata, num_to_add):
+def add_empty_filter_options(attribute_map, metadata, num_to_add, rng):
   # Add some filtering criterion that do NOT correspond to objects
 
   if metadata['dataset'] == 'CLEVR-v1.0':
@@ -572,14 +575,14 @@ def add_empty_filter_options(attribute_map, metadata, num_to_add):
 
   target_size = len(attribute_map) + num_to_add
   while len(attribute_map) < target_size:
-    k = (random.choice(v) for v in attr_vals)
+    k = (rng.choice(v) for v in attr_vals)
     if k not in attribute_map:
       attribute_map[k] = []
 
 
 def find_relate_filter_options(object_idx,
                                scene_struct,
-                               metadata,
+                               metadata, rng,
                                unique=False,
                                include_zero=False,
                                trivial_frac=0.1):
@@ -608,7 +611,7 @@ def find_relate_filter_options(object_idx,
   N, f = len(options), trivial_frac
   num_trivial = int(round(N * f / (1 - f)))
   trivial_options = list(trivial_options.items())
-  random.shuffle(trivial_options)
+  rng.shuffle(trivial_options)
   for k, v in trivial_options[:num_trivial]:
     options[k] = v
 

--- a/third_party/clevr_robot_env_utils/generate_scene.py
+++ b/third_party/clevr_robot_env_utils/generate_scene.py
@@ -16,7 +16,6 @@ from __future__ import division
 from __future__ import print_function
 
 import math
-import random
 import numpy as np
 
 

--- a/third_party/clevr_robot_env_utils/generate_scene.py
+++ b/third_party/clevr_robot_env_utils/generate_scene.py
@@ -36,7 +36,7 @@ def camera_transformation_from_pose(azimutal, elevation):
   return r, np.linalg.inv(r)
 
 
-def generate_scene_struct(c2w, min_dist, max_dist, num_object=3, coords=None):
+def generate_scene_struct(c2w, min_dist, max_dist, rng, num_object=3, coords=None):
   """Generate a random scene struct."""
   # This will give ground-truth information about the scene and its objects
   scene_struct = {
@@ -66,7 +66,7 @@ def generate_scene_struct(c2w, min_dist, max_dist, num_object=3, coords=None):
 
   # Now make some random objects
   # objects = add_random_objects(scene_struct, num_object, metadata=metadata)
-  objects = add_objects_grid(num_object, min_dist, max_dist, coords)
+  objects = add_objects_grid(num_object, min_dist, max_dist, rng, coords)
   scene_struct['objects'] = objects
   scene_struct['relationships'] = compute_relationship(scene_struct)
   return objects, scene_struct
@@ -81,7 +81,7 @@ def no_overlap(new_x, new_y, positions, radius):
 def is_within_bounds(x, y, min_dist, max_dist):
   return min_dist <= x <= max_dist and min_dist <= y <= max_dist
 
-def add_objects_grid(num_objects, min_dist, max_dist, coords=None, grid_obj_radius=0.1):
+def add_objects_grid(num_objects, min_dist, max_dist, rng, coords=None, grid_obj_radius=0.1):
   positions = []
   objects = []
   
@@ -101,22 +101,22 @@ def add_objects_grid(num_objects, min_dist, max_dist, coords=None, grid_obj_radi
   list_grid_dirs = [(x, y) for x in [-grid_obj_radius*4.0, -grid_obj_radius*2.0, 0, grid_obj_radius*2.0, grid_obj_radius*4.0] for y in [-grid_obj_radius*4.0, -grid_obj_radius*2.0, 0, grid_obj_radius*2.0, grid_obj_radius*4.0] if not (x == 0 and y == 0)]
   
   if not coords:
-    x = random.uniform(min_dist, max_dist)
-    y = random.uniform(min_dist, max_dist)
+    x = rng.uniform(min_dist, max_dist)
+    y = rng.uniform(min_dist, max_dist)
   else:
     x = coords[0][0]
     y = coords[0][1]
   
   for i in range(num_objects):
-    size_name, r = random.choice(size_mapping)
-    shape_name, shape = random.choice(shape_mapping)
+    size_name, r = rng.choice(size_mapping)
+    shape_name, shape = rng.choice(shape_mapping)
     color_name, color = color_mapping[i]
-    mat_name = random.choice(material_mapping)
+    mat_name = rng.choice(material_mapping)
     
     # First object
     if i == 0:
       positions.append((x, y, r))
-      theta = 360.0 * random.random()
+      theta = 360.0 * rng.random()
       objects.append({
           'shape': shape,
           'shape_name': shape_name,
@@ -131,7 +131,7 @@ def add_objects_grid(num_objects, min_dist, max_dist, coords=None, grid_obj_radi
       
     last_x, last_y, _ = positions[-1]
     
-    random.shuffle(list_grid_dirs)
+    rng.shuffle(list_grid_dirs)
 
     if not coords:
       for dx, dy in list_grid_dirs:
@@ -144,7 +144,7 @@ def add_objects_grid(num_objects, min_dist, max_dist, coords=None, grid_obj_radi
       new_y = coords[i][1]
         
     positions.append((new_x, new_y, r))
-    theta = 360.0 * random.random()
+    theta = 360.0 * rng.random()
     objects.append({
       'shape': shape,
       'shape_name': shape_name,
@@ -234,7 +234,7 @@ def add_fixed_objects(scene_struct,
   return objects
 
 def add_random_objects(scene_struct,
-                       num_objects,
+                       num_objects, rng,
                        max_retries=10,
                        min_margin=0.01,
                        min_dist=0.1,
@@ -269,15 +269,15 @@ def add_random_objects(scene_struct,
   for i in range(num_objects):
 
     if not metadata:
-      size_name, r = random.choice(size_mapping)
-      shape_name, shape = random.choice(shape_mapping)
+      size_name, r = rng.choice(size_mapping)
+      shape_name, shape = rng.choice(shape_mapping)
       if not metadata:
         color_name, color = color_mapping[i]
       else:
-        color_name, color = random.choice(color_mapping)
-      mat_name = random.choice(material_mapping)
+        color_name, color = rng.choice(color_mapping)
+      mat_name = rng.choice(material_mapping)
     else:
-      idx = random.choice(list(range(len(all_combination))))
+      idx = rng.choice(list(range(len(all_combination))))
       size_tuple, shape_tuple, color_tuple, mat_tuple = all_combination.pop(idx)
       size_name, r = size_tuple
       shape_name, shape = shape_tuple
@@ -288,9 +288,9 @@ def add_random_objects(scene_struct,
     while True:
       num_tries += 1
       if num_tries > max_retries:
-        return add_random_objects(scene_struct, num_objects, metadata=metadata)
-      x = random.uniform(-0.5, 0.5)
-      y = random.uniform(-0.3, 0.5)
+        return add_random_objects(scene_struct, num_objects, rng, metadata=metadata)
+      x = rng.uniform(-0.5, 0.5)
+      y = rng.uniform(-0.3, 0.5)
       dists_good, margins_good = True, True
       for (xx, yy, rr) in positions:
         dx, dy = x - xx, y - yy
@@ -317,7 +317,7 @@ def add_random_objects(scene_struct,
       r /= 1.2
 
     positions.append((x, y, r))
-    theta = 360.0 * random.random()
+    theta = 360.0 * rng.random()
     objects.append({
         'shape': shape,
         'shape_name': shape_name,
@@ -332,7 +332,7 @@ def add_random_objects(scene_struct,
 
 
 def randomly_perturb_objects(scene_struct,
-                             old_objects,
+                             old_objects, rng,
                              max_retries=10,
                              min_margin=0.01,
                              min_dist=0.1):
@@ -352,9 +352,9 @@ def randomly_perturb_objects(scene_struct,
     while True:
       num_tries += 1
       if num_tries > max_retries:
-        return randomly_perturb_objects(scene_struct, old_objects)
-      x = random.uniform(-0.5, 0.5)
-      y = random.uniform(-0.3, 0.5)
+        return randomly_perturb_objects(scene_struct, old_objects, rng)
+      x = rng.uniform(-0.5, 0.5)
+      y = rng.uniform(-0.3, 0.5)
       dists_good, margins_good = True, True
       for (xx, yy, rr) in positions:
         dx, dy = x - xx, y - yy
@@ -375,7 +375,7 @@ def randomly_perturb_objects(scene_struct,
         break
 
     positions.append((x, y, r))
-    theta = 360.0 * random.random()
+    theta = 360.0 * rng.random()
     objects.append({
         'shape': shape,
         'shape_name': shape_name,

--- a/utils/seeding_utils.py
+++ b/utils/seeding_utils.py
@@ -1,0 +1,4 @@
+import random
+
+def create_rng(seed):
+    return random.Random(seed)


### PR DESCRIPTION
In the ClevrGridEnv, added the ability to pass a seed to make things reproducible with the same seed. 

This is also going to help us in debugging together because we can specify problematic scenarios by seeds. 

When we want to generate results across different scenarios, we can report them across different scenarios where each is uniquely identified by a seed, thus enabling the regeneration of almost identical reporting results.